### PR TITLE
SPAR-444: publish @nulogy/icons to GitHub Packages

### DIFF
--- a/.github/workflows/mirror-to-github-packages.yml
+++ b/.github/workflows/mirror-to-github-packages.yml
@@ -1,0 +1,41 @@
+name: Mirror versions to GitHub Packages
+
+# One-off (SPAR-444): republish existing npmjs versions of this package to
+# GitHub Packages. semantic-release only publishes versions forward, so the
+# older versions consumers still pin have to be mirrored for them to install
+# from GitHub Packages.
+
+on:
+  workflow_dispatch:
+    inputs:
+      versions:
+        description: "Space-separated npmjs versions to mirror (e.g. 4.39.0 4.38.1)"
+        required: true
+
+permissions:
+  packages: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+          scope: "@nulogy"
+      - name: Mirror npmjs -> GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKG: "@nulogy/icons"
+          VERSIONS: ${{ inputs.versions }}
+        run: |
+          set -euo pipefail
+          for v in $VERSIONS; do
+            echo "::group::$PKG@$v"
+            # Pack from npmjs — the @nulogy scope is pointed at GitHub Packages
+            # for publish, so override it back to npmjs just for the fetch.
+            tarball=$(npm pack "$PKG@$v" --@nulogy:registry=https://registry.npmjs.org 2>/dev/null | tail -1)
+            npm publish "$tarball" --access restricted
+            echo "::endgroup::"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-      # Required for OIDC to let NPM registry know
-      # that this workflow is trusted
-      id-token: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -45,3 +43,5 @@ jobs:
           branch: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # @semantic-release/npm authenticates via NPM_TOKEN, not NODE_AUTH_TOKEN
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,11 +6,18 @@
 
 ## 📦 Installation
 
-The icons are required as a peer dependency of `@nulogy/components`. They are published to [GitHub Packages](https://docs.github.com/en/packages) under the `@nulogy` scope, so point the scope at GitHub Packages in your `.npmrc` and authenticate with a token that has `read:packages`:
+The icons are required as a peer dependency of `@nulogy/components`. They are published to [GitHub Packages](https://docs.github.com/en/packages) under the `@nulogy` scope, so point the scope at GitHub Packages in your `.npmrc`:
 
 ```
 @nulogy:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+//npm.pkg.github.com/:_authToken=${GITHUB_NPM_AUTH_TOKEN}
+```
+
+GitHub Packages requires authentication even for reads. No personal access token is needed — reuse your GitHub CLI login:
+
+```sh
+gh auth refresh -h github.com -s read:packages   # one-time
+export GITHUB_NPM_AUTH_TOKEN=$(gh auth token)     # add to your shell profile
 ```
 
 Then install:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@
 
 ## 📦 Installation
 
-The icons are required as a peer dependency of `@nulogy/components`. You can install them using:
+The icons are required as a peer dependency of `@nulogy/components`. They are published to [GitHub Packages](https://docs.github.com/en/packages) under the `@nulogy` scope, so point the scope at GitHub Packages in your `.npmrc` and authenticate with a token that has `read:packages`:
+
+```
+@nulogy:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+```
+
+Then install:
 
 `$ yarn add @nulogy/icons`
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "repository": "https://github.com/nulogy/nds-icons",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
   },
   "main": "dist/main.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What

Switch `@nulogy/icons` publishing from public npmjs to **GitHub Packages** (`npm.pkg.github.com`), keeping the `@nulogy` scope.

Part of [SPAR-444](https://nulogy-go.atlassian.net/browse/SPAR-444). Yarn allows only one registry per package scope, so `@nulogy/*` on npmjs and the private `@nulogy/spark-ui` on GitHub Packages cannot both install in PackManager. Consolidating the NDS family (`@nulogy/components`, `@nulogy/icons`, `@nulogy/tokens`) onto GitHub Packages resolves the conflict without exposing spark-ui publicly.

## Changes

- `package.json` → `publishConfig.registry = https://npm.pkg.github.com`, `access: restricted`
- `.github/workflows/release.yml`: add `packages: write`; remove `id-token: write` (npm OIDC trusted publishing is npmjs-only, inert for GitHub Packages); authenticate `@semantic-release/npm` via `NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}` (the plugin reads `NPM_TOKEN`, not `NODE_AUTH_TOKEN`)
- README: install from the `@nulogy` GitHub Packages registry

## Publishing sequencing

- **Merging this does not publish.** The commit is `ci:`-typed, so semantic-release cuts no release on merge. The first GitHub Packages release happens on the next releasable (`feat:`/`fix:`) commit to `main`; the version continues from existing git tags (stays on the current major), satisfying PackManager's current range.
- `npm whoami` is skipped for non-default registries, so verify needs only `NPM_TOKEN` present (@semantic-release/npm `verify-auth.js`).

## Related

- Companion PRs (all three must land together): `nulogy/design-system`, `nulogy/nds-icons`, `nulogy/nds-tokens`
- Follow-up (PackManager): point the `@nulogy` scope at GitHub Packages and drop the `file:` spark-ui dependency.

[SPAR-444]: https://nulogy-go.atlassian.net/browse/SPAR-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ